### PR TITLE
fix: 🐛 missing `parserOptions.project` is now set properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ settings:
 
 This can be overridden exactly the same as the [`eslint-import-resolver-webpack`](https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack#eslint-import-resolver-webpack) configuration
 
+### Using typescript?
+
+This config uses some rules that require type information like [naming-convention](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md#selector-options), so `@typescript-eslint/parser`'s [`parserOptions.project`](https://eslint.org/docs/user-guide/configuring#specifying-parser-options) is set to `"./tsconfig.json"`. Override this value if your `tsconfig.json` is located somewhere else.
+
 [actions-badge]: https://img.shields.io/github/workflow/status/comparto/eslint-config/Release?label=actions&logo=github-actions&style=flat-square
 [version-badge]: https://img.shields.io/npm/v/@comparto/eslint-config.svg?logo=npm&style=flat-square
 [package]: https://www.npmjs.com/package/@comparto/eslint-config

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,0 +1,5 @@
+const path = require('path')
+
+module.exports = {
+  tsConfigPath: () => path.join(process.cwd(), './tsconfig.json')
+}

--- a/src/rules/typescript.js
+++ b/src/rules/typescript.js
@@ -1,9 +1,14 @@
+const { tsConfigPath } = require('../paths')
+
 module.exports = {
   overrides: [
     {
       files: ['**/*.ts?(x)'],
       plugins: ['@typescript-eslint'],
       parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: tsConfigPath()
+      },
       settings: {
         'import/external-module-folders': [
           'node_modules',

--- a/tests/__snapshots__/typescript.test.js.snap
+++ b/tests/__snapshots__/typescript.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`typescript.js 1`] = `
+exports[`typescript.js should create default configuration 1`] = `
 Object {
   "overrides": Array [
     Object {
@@ -8,6 +8,9 @@ Object {
         "**/*.ts?(x)",
       ],
       "parser": "@typescript-eslint/parser",
+      "parserOptions": Object {
+        "project": "mock-tsconfig-path",
+      },
       "plugins": Array [
         "@typescript-eslint",
       ],

--- a/tests/typescript.test.js
+++ b/tests/typescript.test.js
@@ -1,5 +1,16 @@
 const typescript = require('../src/rules/typescript')
 
-test('typescript.js', () => {
-  expect(typescript).toMatchSnapshot()
+jest.mock('../src/paths', () => ({
+  tsConfigPath: () => 'mock-tsconfig-path'
+}))
+
+describe('typescript.js', () => {
+  it('should create default configuration', () => {
+    expect(typescript).toMatchSnapshot()
+  })
+  it('should have parserOptions.project set correctly', () => {
+    const parserOptions = typescript.overrides[0].parserOptions
+
+    expect(parserOptions.project).toBe('mock-tsconfig-path')
+  })
 })


### PR DESCRIPTION
parserOptions.project is set to "./tsconfig.json" for
"@typescript-eslint/parser"

✅ Closes: #27