### PR TITLE
feat: 🎸 `prettier` rules are now decoupled from eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# yalc
+.yalc
+yalc.lock

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,7 +1,0 @@
-semi: false
-singleQuote: true
-printWidth: 80
-jsxSingleQuote: true
-arrowParens: avoid
-trailingComma: none
-quoteProps: consistent

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 # @comparto/eslint-config
 
-This package provides a shareable ESLint configuration that includes `jest`, `typescript`, `jsx-a11y`, `react` and `prettier` configurations.
+This package provides a shareable ESLint configuration with reasonable rules for react, typescript and javascript.
 
-## Usage
+## Usage:
 
 1. Install stuff:
 
@@ -16,7 +16,7 @@ This package provides a shareable ESLint configuration that includes `jest`, `ty
    npx install-peerdeps --dev @comparto/eslint-config
    ```
 
-   or if you wish this to be a common dependency in a yarn workspaces monorepo
+   or if you wish this to be a common dependency in a yarn workspaces monorepo:
 
    ```sh
    # -Y --yarn, -x --extra-args, -W --ignore-workspace-root-check
@@ -24,6 +24,14 @@ This package provides a shareable ESLint configuration that includes `jest`, `ty
    ```
 
 1. Add `"extends": "@comparto/eslint-config"` to your `.eslintrc`
+
+### Prettier:
+
+```sh
+yarn add -D @comparto/eslint-config
+```
+
+Add `"prettier": "@comparto/prettier-config"` to your `package.json` or any [configuration](https://prettier.io/docs/en/configuration.html) of your choice.
 
 ### Using webpack aliases?
 
@@ -36,7 +44,7 @@ settings:
       config: 'webpack.dev.config.js' # or {} if not found
 ```
 
-This can be overridden exactly the same as the [`eslint-import-resolver-webpack`](https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack#eslint-import-resolver-webpack) configuration
+This can be overridden exactly the same as the [`eslint-import-resolver-webpack`](https://github.com/benmosher/eslint-plugin-import/tree/master/resolvers/webpack#eslint-import-resolver-webpack) configuration.
 
 ### Using typescript?
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:coverage": "jest --coverage",
     "test:ci": "yarn test:coverage"
   },
+  "prettier": "@comparto/prettier-config",
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"
@@ -57,6 +58,7 @@
     "eslint-plugin-react-hooks": "^4.0.4"
   },
   "devDependencies": {
+    "@comparto/prettier-config": "^1.0.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "eslint": "^7.2.0",

--- a/src/rules/style.js
+++ b/src/rules/style.js
@@ -1,9 +1,4 @@
 module.exports = {
-  env: {
-    browser: true,
-    es6: true,
-    node: true
-  },
   extends: [
     'plugin:prettier/recommended',
     'prettier/react',
@@ -11,18 +6,5 @@ module.exports = {
     'plugin:jest/style'
   ],
   plugins: ['prettier', 'jest'],
-  rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        semi: false,
-        singleQuote: true,
-        printWidth: 80,
-        jsxSingleQuote: true,
-        arrowParens: 'avoid',
-        trailingComma: 'none',
-        quoteProps: 'consistent'
-      }
-    ]
-  }
+  rules: { 'prettier/prettier': 'error' }
 }

--- a/tests/__snapshots__/style.test.js.snap
+++ b/tests/__snapshots__/style.test.js.snap
@@ -1,12 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`style.js 1`] = `
+exports[`style.js should create default configuration 1`] = `
 Object {
-  "env": Object {
-    "browser": true,
-    "es6": true,
-    "node": true,
-  },
   "extends": Array [
     "plugin:prettier/recommended",
     "prettier/react",
@@ -18,18 +13,7 @@ Object {
     "jest",
   ],
   "rules": Object {
-    "prettier/prettier": Array [
-      "error",
-      Object {
-        "arrowParens": "avoid",
-        "jsxSingleQuote": true,
-        "printWidth": 80,
-        "quoteProps": "consistent",
-        "semi": false,
-        "singleQuote": true,
-        "trailingComma": "none",
-      },
-    ],
+    "prettier/prettier": "error",
   },
 }
 `;

--- a/tests/style.test.js
+++ b/tests/style.test.js
@@ -1,5 +1,11 @@
 const style = require('../src/rules/style')
 
-test('style.js', () => {
-  expect(style).toMatchSnapshot()
+describe('style.js', () => {
+  it('should create default configuration', () => {
+    expect(style).toMatchSnapshot()
+  })
+
+  it('should not have prettier rules', () => {
+    expect(style.rules['prettier/prettier']).toBe('error')
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@comparto/prettier-config@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@comparto/prettier-config/-/prettier-config-1.0.0.tgz#eaeafb4cc4552a612aa63baa5013cf542f01e611"
+  integrity sha512-1h86wq/UEFwg7ScR2N+o87s5RpZEmMRr7kHh51BjRLlFZviaZiqVmi920pSCNWqFSonGQaMuuV/KoLG9IQNAbQ==
+
 "@iarna/cli@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz#0f7af5e851afe895104583c4ca07377a8094d641"


### PR DESCRIPTION
BREAKING CHANGE: Install [`@comparto/prettier-config`](https://github.com/comparto/prettier-config) to retain prettier rules.

✅ Closes: #31